### PR TITLE
[ILKAN-103] 공간 상세조회 UI 구현

### DIFF
--- a/src/assets/arrow-left.svg
+++ b/src/assets/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="19" viewBox="0 0 10 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.33334 1L1 9.33334L9.33334 17.6667" stroke="#092F63" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/arrow-right.svg
+++ b/src/assets/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="19" viewBox="0 0 10 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.666656 1L9 9.33334L0.666656 17.6667" stroke="#092F63" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/kanMatch/imageSlider.tsx
+++ b/src/components/kanMatch/imageSlider.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import sliderStyles from "../../css/components/kanMatch/imageSlider.module.css"; //이부분 내가 적은거라 틀릴수 있으니 다시 확인
+import arrowLeft from "../../assets/arrow-left.svg"; // 화살표 이미지 경로에 맞게 수정
+import arrowRight from "../../assets/arrow-right.svg"; // 화살표 이미지 경로에 맞게 수정
+
+type ImageSliderProps = {
+  images: string[];
+};
+
+export default function ImageSlider({ images }: ImageSliderProps) {
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
+  const handlePrev = () => {
+    setCurrentImageIndex((prevIndex) =>
+      prevIndex === 0 ? images.length - 1 : prevIndex - 1
+    );
+  };
+
+  const handleNext = () => {
+    setCurrentImageIndex((prevIndex) =>
+      prevIndex === images.length - 1 ? 0 : prevIndex + 1
+    );
+  };
+
+  return (
+    <div className={sliderStyles.sliderContainer}>
+      <img
+        src={images[currentImageIndex]}
+        alt={`슬라이드 이미지 ${currentImageIndex + 1}`}
+        className={sliderStyles.sliderImage}
+      />
+      {images.length > 1 && (
+        <>
+          <button className={sliderStyles.prevButton} onClick={handlePrev}>
+            <img src={arrowLeft} alt="이전" />
+          </button>
+          <button className={sliderStyles.nextButton} onClick={handleNext}>
+            <img src={arrowRight} alt="다음" />
+          </button>
+        </>
+      )}
+      <div className={sliderStyles.pagination}>
+        {images.map((_, index) => (
+          <div
+            key={index}
+            className={`${sliderStyles.dot} ${
+              index === currentImageIndex ? sliderStyles.active : ""
+            }`}
+          ></div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/css/components/kanMatch/imageSlider.module.css
+++ b/src/css/components/kanMatch/imageSlider.module.css
@@ -1,0 +1,68 @@
+.sliderContainer {
+  position: relative;
+  width: 100%;
+  height: 500px; /* 원하는 높이로 조정하세요 */
+  margin: 0 auto 2rem;
+  overflow: hidden;
+  background-color: #f0f0f0;
+}
+
+.sliderImage {
+  width: 100%;
+  height: 576px;
+  object-fit: cover; /* 이미지가 잘리지 않고 컨테이너를 채우도록 설정 */
+  transition: transform 0.3s ease-in-out;
+}
+
+.prevButton,
+.nextButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: white;
+  padding: 10px;
+  cursor: pointer;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.prevButton {
+  left: 10px;
+}
+
+.nextButton {
+  right: 10px;
+}
+
+.prevButton img,
+.nextButton img {
+  width: 24px;
+  height: 24px;
+  filter: invert(1); /* SVG 아이콘 색상을 흰색으로 변경 */
+}
+
+.pagination {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.dot.active {
+  background-color: white;
+}

--- a/src/css/pages/kanDetailPage.module.css
+++ b/src/css/pages/kanDetailPage.module.css
@@ -1,0 +1,259 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+  width: 89%;
+  padding: 0 90px; /* x축 패딩 90px */
+}
+
+.applyBtn {
+  display: block;
+  width: 698px;
+  height: 120px;
+  flex-shrink: 0;
+  border-radius: 60px;
+  border: none;
+  background: #5290ff;
+  text-decoration: none;
+  color: white;
+  text-align: center;
+  line-height: 120px;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.kanPosting {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 1061px;
+  height: 700px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  box-sizing: border-box;
+  background: #f5f6f8;
+}
+
+.kanPostingAddress {
+  display: flex;
+  width: 875px;
+  height: 29px;
+  flex-direction: column;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 70px; /* 350% */
+  margin-top: 35px;
+}
+
+.kanPostingSubtitle {
+  width: 875px;
+  height: 128px;
+  flex-shrink: 0;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 48px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 70px; /* 145.833% */
+
+  margin-top: 12px;
+}
+
+.kanPostingWriter {
+  width: 875px;
+  height: 36px;
+  flex-shrink: 0;
+  display: flex;
+  margin-top: 38px;
+  gap: 12px;
+}
+
+.kanPostingWriterName {
+  width: 199px;
+  height: 36px;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 40px; /* 200% */
+}
+
+.line {
+  width: 1000px;
+  height: 1px;
+  flex-shrink: 0;
+  stroke-width: 1px;
+  stroke: #d9d9d9;
+  margin-bottom: 28px;
+}
+
+.infoBox {
+  width: 427px;
+  height: 96px;
+  flex-shrink: 0;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px 24px;
+  margin-top: 24px;
+}
+
+.infoContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.infoDetail {
+  display: flex;
+  width: 284.326px;
+  height: 33px;
+  flex-direction: column;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 40px;
+}
+
+.infoRentalFee {
+  display: flex;
+}
+
+.infoDate {
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 900;
+  line-height: 40px; /* 166.667% */
+}
+
+.infoRentalFeeValue {
+  color: #5290ff;
+  font-family: "Noto Sans KR";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 900;
+  line-height: 40px;
+}
+
+.infoIcon {
+  margin-left: 36px;
+}
+
+.postingArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 1061px;
+  height: 450px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: #f5f6f8;
+}
+
+.postingAreaSubtitle {
+  display: flex;
+  width: 875px;
+  height: 29px;
+  flex-direction: column;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 70px; /* 218.75% */
+  margin-bottom: 32px;
+  margin-top: 38px;
+}
+
+.postingAreaImageGrid {
+  display: flex;
+  width: 880px;
+  gap: 26px;
+}
+
+.postingAreaImageBox {
+  width: 427px;
+  height: 320px;
+  flex-shrink: 0;
+  background: #d9d9d9;
+}
+
+.detailArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 1061px;
+  height: 900px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: #f5f6f8;
+  box-sizing: border-box; /* padding 포함 너비 계산 */
+}
+
+.detailAreaSubtitle {
+  display: flex;
+  width: 875px;
+  height: 29px;
+  flex-direction: column;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 70px; /* 218.75% */
+  margin-bottom: 32px;
+  margin-top: 38px;
+}
+
+.detailAreaContent {
+  width: 875px;
+  height: 741px;
+  flex-shrink: 0;
+  color: #000;
+  font-family: "Noto Sans KR";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 36px; /* 150% */
+}
+
+/* 상세 내용 텍스트 스타일 */
+h4 {
+  font-size: 24px;
+  font-weight: bold;
+  margin-top: 15px;
+  margin-bottom: 5px;
+}
+ul {
+  padding-left: 20px;
+  margin-top: 7px;
+}
+li {
+}
+p {
+  margin-top: 15px;
+  margin-bottom: 10px;
+}

--- a/src/css/pages/kanDetailPage.module.css
+++ b/src/css/pages/kanDetailPage.module.css
@@ -7,6 +7,11 @@
   padding: 0 90px; /* x축 패딩 90px */
 }
 
+.imageSliderBox {
+  width: 1275px; /* container 폭 상속 안받음 */
+  /*부모요소 크기가 89%로 제한되어있어 width를 %로 두니 최종 디자인 본이랑 달라져서 px로 두고 했습니다.*/
+}
+
 .applyBtn {
   display: block;
   width: 698px;

--- a/src/pages/main/kanDetailPage.tsx
+++ b/src/pages/main/kanDetailPage.tsx
@@ -8,13 +8,15 @@ import Phone from "../../assets/telephone.svg";
 import Email from "../../assets/email.svg";
 import CheckIn from "../../assets/check-in.svg";
 import CheckOut from "../../assets/check-out.svg";
+import ImageSlider from "../../components/kanMatch/imageSlider";
+
 // 예상되는 데이터 타입
 export type KanItem = {
   id: number;
   title: string;
   writer: string;
   price: string;
-  image?: string;
+  images: string[];
 };
 
 // 임시 데이터
@@ -24,10 +26,10 @@ const MOCK_LIST: KanItem[] = Array.from({ length: 15 }).map((_, i) => ({
   writer: "김성철",
   price: "50,000원",
   images: [
-    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_1`,
-    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_2`,
-    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_3`,
-    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_4`,
+    `https://via.placeholder.com/1000x600?text=Job+ID+${i + 1}_1`,
+    `https://via.placeholder.com/1000x600?text=Job+ID+${i + 1}_2`,
+    `https://via.placeholder.com/1000x600?text=Job+ID+${i + 1}_3`,
+    `https://via.placeholder.com/1000x600?text=Job+ID+${i + 1}_4`,
   ],
 }));
 
@@ -45,6 +47,9 @@ export default function KanDetailPage() {
 
   return (
     <div className={styles.container}>
+      <div className={styles.imageSliderBox}>
+        <ImageSlider images={kanItem.images} />
+      </div>
       <div className={styles.kanPosting}>
         <div className={styles.kanPostingAddress}>경산시 조영동 348-19</div>
         <div className={styles.kanPostingSubtitle}>{kanItem.title}</div>

--- a/src/pages/main/kanDetailPage.tsx
+++ b/src/pages/main/kanDetailPage.tsx
@@ -1,0 +1,160 @@
+import { Link, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import styles from "../../css/pages/kanDetailPage.module.css";
+import Writer from "../../assets/writer.svg";
+import Date from "../../assets/date.svg";
+import Salary from "../../assets/salary.svg";
+import Phone from "../../assets/telephone.svg";
+import Email from "../../assets/email.svg";
+import CheckIn from "../../assets/check-in.svg";
+import CheckOut from "../../assets/check-out.svg";
+// 예상되는 데이터 타입
+export type KanItem = {
+  id: number;
+  title: string;
+  writer: string;
+  price: string;
+  image?: string;
+};
+
+// 임시 데이터
+const MOCK_LIST: KanItem[] = Array.from({ length: 15 }).map((_, i) => ({
+  id: i + 1,
+  title: "경산시 공유 오피스 회의실, 모던, 화이트톤, 집중이 잘 되는 오피스",
+  writer: "김성철",
+  price: "50,000원",
+  images: [
+    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_1`,
+    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_2`,
+    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_3`,
+    `https://via.placeholder.com/300x200?text=Job+ID+${i + 1}_4`,
+  ],
+}));
+
+export default function KanDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [kanItem, setKanItem] = useState<KanItem | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const item = MOCK_LIST.find((w) => w.id === Number(id));
+    setKanItem(item || null);
+  }, [id]);
+
+  if (!kanItem) return <div>공간 정보를 찾을 수 없습니다.</div>;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.kanPosting}>
+        <div className={styles.kanPostingAddress}>경산시 조영동 348-19</div>
+        <div className={styles.kanPostingSubtitle}>{kanItem.title}</div>
+        <div className={styles.kanPostingWriter}>
+          <img src={Writer}></img>
+          <div className={styles.kanPostingWriterName}>{kanItem.writer}</div>
+        </div>
+        <div className={styles.line}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1000"
+            height="2"
+            viewBox="0 0 1000 2"
+            fill="none"
+          >
+            <path d="M0 1H1000" stroke="#D9D9D9" />
+          </svg>
+        </div>
+        <div className={styles.infoGrid}>
+          <div className={styles.infoBox}>
+            <img src={Date} className={styles.infoIcon} alt="날짜 아이콘" />
+            <div className={styles.infoContent}>
+              <label className={styles.infoLabel}>회의실 유형</label>
+              <span className={styles.infoDetail}>공유 오피스</span>
+            </div>
+          </div>
+          <div className={styles.infoBox}>
+            <img src={Salary} className={styles.infoIcon} alt="날짜 아이콘" />
+            <div className={styles.infoContent}>
+              <label className={styles.infoLabel}>대여비</label>
+              <div className={styles.infoRentalFee}>
+                <span className={styles.infoDate}>일/</span>
+                <span className={styles.infoRentalFeeValue}>
+                  {kanItem.price}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className={styles.infoBox}>
+            <img src={Email} className={styles.infoIcon} alt="이메일 아이콘" />
+            <div className={styles.infoContent}>
+              <label className={styles.infoLabel}>이메일</label>
+              <span className={styles.infoDetail}>highfive@naver.com</span>
+            </div>
+          </div>
+          <div className={styles.infoBox}>
+            <img src={Phone} className={styles.infoIcon} alt="전화기 아이콘" />
+            <div className={styles.infoContent}>
+              <label className={styles.infoLabel}>전화</label>
+              <span className={styles.infoDetail}>010-0000-5555</span>
+            </div>
+          </div>
+          <div className={styles.infoBox}>
+            <img src={CheckIn} className={styles.infoIcon} alt="입실 아이콘" />
+            <div className={styles.infoContent}>
+              <label className={styles.infoLabel}>입실시간</label>
+              <span className={styles.infoDetail}>08:00 ~</span>
+            </div>
+          </div>
+          <div className={styles.infoBox}>
+            <img src={CheckOut} className={styles.infoIcon} alt="퇴실 아이콘" />
+            <div className={styles.infoContent}>
+              <label className={styles.infoLabel}>퇴실시간</label>
+              <span className={styles.infoDetail}>~/23:00</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className={styles.postingArea}>
+        <span className={styles.postingAreaSubtitle}>사진 첨부</span>
+        <div className={styles.postingAreaImageGrid}>
+          <div className={styles.postingAreaImageBox}></div>
+          <div className={styles.postingAreaImageBox}></div>
+        </div>
+      </div>
+      <div className={styles.detailArea}>
+        <span className={styles.detailAreaSubtitle}>상세설명</span>
+        <div className={styles.detailAreaContent}>
+          <h4>[공실 설명]</h4>
+          <p>
+            경산시 조영동에 위치한 화이트톤의 현대적인 공유 오피스입니다. 넓은
+            채광창으로 자연광이 가득 들어와, 회의나 팀작업, 스타트업 사무
+            공간으로 최적입니다. 인근에 카페·편의점·버스 정류장이 있어 접근성이
+            좋습니다.
+          </p>
+
+          <h4>편의시설 및 제공 서비스</h4>
+          <ul className={styles.bulletList}>
+            <li>• 무료 와이파이: 고속 무선 인터넷 지원</li>
+            <li>• 전원 콘센트: 좌석마다 개별 구비</li>
+            <li>• 화이트보드 및 마커: 회의·브레인스토밍 가능</li>
+            <li>• 에어컨/난방 완비: 사계절 쾌적한 환경 유지</li>
+            <li>• 공용 프린터: 흑백/컬러 인쇄 가능(유료)</li>
+            <li>• 셀프 카페 코너: 커피·차 제공</li>
+          </ul>
+
+          <h4>제한 사항</h4>
+          <ul className={styles.bulletList}>
+            <li>• 주차 공간 협소 (인근 유료주차장 이용 권장)</li>
+            <li>• 흡연 불가 (건물 외부 지정 흡연구역 이용)</li>
+            <li>• 반려동물 동반 불가</li>
+            <li>• 대형 소음 발생 행사 불가 (음악 공연, 방송 촬영 등)</li>
+          </ul>
+
+          <p>*자세한 문의사항은 위 번호로 연락주세요*</p>
+        </div>
+      </div>
+      <Link to={`/main/kanMatch/${id}/application`} className={styles.applyBtn}>
+        지원하기
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

ILKAN-103

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="858" height="816" alt="스크린샷 2025-08-15 001840" src="https://github.com/user-attachments/assets/318defee-2bd1-49f1-bcd5-073e8bb24e64" />
<img width="738" height="851" alt="image" src="https://github.com/user-attachments/assets/bc43b6f1-b78d-43d7-aec8-37f4a5eaa7fb" />

이미지 슬라이더 컴포넌트를 제작

목데이터 형식으로 이미지를 받아서 우측/좌측 클릭 시 넘어가도록 구현

kandetailpage에 탑재

kanmatch 컴포넌트 클릭 시 → kandetailpage로 이동하도록 구현

kandetailpage는 화면 상에 보여야 하므로 pages 폴더에서 작업

기존 kanMatchpage의 목데이터를 동일 폴더에서 재사용할 수 없어서, 목데이터를 동일하게 복사해 코드에 포함

지원하기 버튼 클릭 시 → 다음 링크 (application)로 이동

최종 디자인 반영 완료


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
imageslider 의 가로 크기가 현재 전체 container의 89% 속성에 걸려서 원본 디자인 만큼 가로로 넓어지지 않는 문제가 있어 그냥 px로 처리 했습니다 , 자세한 사항은 따로 여쭤봐주시면 어떤 부분에서 막혔는지 말씀드리겠습니다
